### PR TITLE
Always use cursor relative movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ Stop the current mode. Fails if no mode is currently active.
 
 #### `winmove.move_window`
 
-Move a window (does not need to be the current window). See [this showcase](#moving-around-windows).
+Move a window (does not need to be the current window). See [this
+showcase](#moving-around-windows). This takes the cursor position in the window
+[into account](#moving-using-relative-cursor-position) when moving.
 
 ```lua
 ---@param win_id integer
@@ -205,7 +207,8 @@ winmove.move_window(1000, "k")
 
 #### `winmove.split_into`
 
-Split into a window (does not need to be the current window). See [this showcase](#split-into-other-windows).
+Split into a window (does not need to be the current window). See [this showcase](#split-into-other-windows). This takes the cursor position in the window
+[into account](#moving-using-relative-cursor-position) when splitting into.
 
 ```lua
 ---@param win_id integer
@@ -232,7 +235,7 @@ winmove.move_window_far(1000, "h")
 
 #### `winmove.swap_window_in_direction`
 
-Swap a window in a given direction (does not need to be the current window).
+Swap a window in a given direction (does not need to be the current window). This takes the cursor position in the window [into account](#moving-using-relative-cursor-position) when swapping.
 
 ```lua
 ---@param win_id integer

--- a/lua/winmove/init.lua
+++ b/lua/winmove/init.lua
@@ -203,7 +203,7 @@ local function move_window(win_id, dir)
     ---@cast target_win_id -nil
 
     if not layout.are_siblings(win_id, target_win_id) then
-        dir = layout.get_sibling_relative_dir(win_id, target_win_id, dir, winmove.current_mode())
+        dir = layout.get_sibling_relative_dir(win_id, target_win_id, dir)
     end
 
     winutil.wincall_no_events(

--- a/lua/winmove/init.lua
+++ b/lua/winmove/init.lua
@@ -249,8 +249,7 @@ local function split_into(win_id, dir)
     }
 
     if layout.are_siblings(win_id, target_win_id) then
-        local reldir =
-            layout.get_sibling_relative_dir(win_id, target_win_id, dir)
+        local reldir = layout.get_sibling_relative_dir(win_id, target_win_id, dir)
 
         split_options.vertical = not split_options.vertical
         split_options.rightbelow = reldir == "l" or reldir == "j"

--- a/lua/winmove/init.lua
+++ b/lua/winmove/init.lua
@@ -250,7 +250,7 @@ local function split_into(win_id, dir)
 
     if layout.are_siblings(win_id, target_win_id) then
         local reldir =
-            layout.get_sibling_relative_dir(win_id, target_win_id, dir, winmove.current_mode())
+            layout.get_sibling_relative_dir(win_id, target_win_id, dir)
 
         split_options.vertical = not split_options.vertical
         split_options.rightbelow = reldir == "l" or reldir == "j"

--- a/lua/winmove/layout.lua
+++ b/lua/winmove/layout.lua
@@ -17,7 +17,11 @@ local function get_cursor_screen_position(win_id)
     local win_row, win_col = unpack(vim.api.nvim_win_get_position(win_id))
 
     -- Get cursor position in local window space
-    local row, col = vim.fn.winline(), vim.fn.wincol()
+    local row, col
+
+    vim.api.nvim_win_call(win_id, function()
+        row, col = vim.fn.winline(), vim.fn.wincol()
+    end)
 
     return win_row + row, win_col + col
 end
@@ -167,24 +171,10 @@ end
 ---@param source_win_id integer
 ---@param target_win_id integer
 ---@param dir winmove.Direction
----@param mode winmove.Mode?
 ---@return winmove.Direction
-function layout.get_sibling_relative_dir(source_win_id, target_win_id, dir, mode)
-    local grow, gcol
+function layout.get_sibling_relative_dir(source_win_id, target_win_id, dir)
     local bbox = window_bounding_box(target_win_id)
-
-    if mode == Mode.Move then
-        grow, gcol = get_cursor_screen_position(source_win_id)
-    else
-        -- Not in move mode, move relative to the middle of the window in global
-        -- coordinates
-        local win_row, win_col = unpack(vim.api.nvim_win_get_position(source_win_id))
-        local height = bbox.bottom - bbox.top
-        local width = bbox.right - bbox.left
-
-        grow, gcol = win_row + height / 2, win_col + width / 2
-    end
-
+    local grow, gcol = get_cursor_screen_position(source_win_id)
     local vertical = winutil.is_horizontal(dir)
     local pos = 0
     local extents = {} ---@type integer[]


### PR DESCRIPTION
This fixes movement for api functions when using them via keymaps and aligns the behaviour across the api and modes.